### PR TITLE
Fix broken LISTEN argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Prometheus exporter for Tinyproxy.
 
 optional arguments:
   -h, --help    show this help message and exit
-  -l LISTEN     address on which to expose metrics (default ":9240")
+  -l LISTEN     address on which to expose metrics (default "127.0.0.1:9240")
   -s STATHOST   internal statistics page address (default "tinyproxy.stats")
   -t TINYPROXY  tinyproxy address (default "127.0.0.1:8888")
 ```

--- a/tinyproxy_exporter
+++ b/tinyproxy_exporter
@@ -43,8 +43,8 @@ def parse_args():
     parser.add_argument(
         '-l',
         metavar='LISTEN',
-        default=':9240',
-        help='address on which to expose metrics (default ":9240")')
+        default='127.0.0.1:9240',
+        help='address on which to expose metrics (default "127.0.0.1:9240")')
     parser.add_argument(
         '-s',
         metavar='STATHOST',


### PR DESCRIPTION
At the moment the example and the default for the LISTEN argument are broken, because the code expects an address and a port after splitting by :