### PR TITLE
Add tinyproxy v 1.11.1 support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,28 +1,21 @@
+---
 name: Docker
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 on:
   push:
-    branches: [ master ]
-    # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
   pull_request:
-    branches: [ master ]
+    branches:
+      - main
 
 env:
-  # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
-
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -32,8 +25,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
         uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
@@ -42,16 +33,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      # Build and push Docker image with Buildx (don't push on PR)
-      # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,21 +1,28 @@
----
 name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
 on:
   push:
-    branches:
-      - main
-    tags:
-      - 'v*.*.*'
+    branches: [ master ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
   pull_request:
-    branches:
-      - main
+    branches: [ master ]
 
 env:
+  # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
+
 
 jobs:
   build:
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -25,6 +32,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
         uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
@@ -33,12 +42,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:

--- a/tinyproxy_exporter
+++ b/tinyproxy_exporter
@@ -23,15 +23,15 @@ class TinyproxyCollector(object):
         values = re.findall(r'<td[^>]*>\s*(\d+)\s*</td>', response)
         yield GaugeMetricFamily('tinyproxy_connections_open',
                                 'Number of open connections', values[0])
-        yield CounterMetricFamily('tinyproxy_requests_total',
-                                  'Number of requests', values[1])
         yield CounterMetricFamily('tinyproxy_connections_bad_total',
-                                  'Number of bad connections', values[2])
+                                  'Number of bad connections', values[1])
         yield CounterMetricFamily('tinyproxy_connections_denied_total',
-                                  'Number of denied connections', values[3])
+                                  'Number of denied connections', values[2])
         yield CounterMetricFamily(
             'tinyproxy_connections_refused_total',
-            'Number of refused connections due to high load', values[4])
+            'Number of refused connections due to high load', values[3])
+        yield CounterMetricFamily('tinyproxy_requests_total',
+                                  'Number of requests', values[4])
 
 
 def parse_args():

--- a/tinyproxy_exporter
+++ b/tinyproxy_exporter
@@ -40,7 +40,7 @@ def parse_args():
     parser.add_argument(
         '-l',
         metavar='LISTEN',
-        default=':9240',
+        default='9240',
         help='address on which to expose metrics (default ":9240")')
     parser.add_argument(
         '-s',
@@ -57,9 +57,8 @@ def parse_args():
 def main():
     try:
         args = parse_args()
-        addr, port = args.l.split(':')
         REGISTRY.register(TinyproxyCollector(args.s, args.t))
-        start_http_server(int(port), addr)
+        start_http_server(int(args.l))
         while True:
             time.sleep(1)
     except KeyboardInterrupt:

--- a/tinyproxy_exporter
+++ b/tinyproxy_exporter
@@ -19,11 +19,8 @@ class TinyproxyCollector(object):
         handler = urllib.request.ProxyHandler({'http': self.tinyproxy})
         opener = urllib.request.build_opener(handler)
         urllib.request.install_opener(opener)
-        response = urllib.request.urlopen('http://{0}'.format(self.stathost))
-        values = [
-            float(x) for x in re.findall(
-                b'(?:<td>|: )(\d+)(?:</td>|<br />|\n</p>)', response.read())
-        ]
+        response = urllib.request.urlopen('http://tinyproxy.stats').read().decode('utf-8')
+        values = re.findall(r'<td[^>]*>\s*(\d+)\s*</td>', response)
         yield GaugeMetricFamily('tinyproxy_connections_open',
                                 'Number of open connections', values[0])
         yield CounterMetricFamily('tinyproxy_requests_total',


### PR DESCRIPTION
In release v1.11.1 of Tinyproxy, the stats page was changed:
1. HTML `<td>` tags now include class attributes, which breaks regex-based parsing
2. The order of metrics has changed - the "number of total requests" was moved to the end, shifting index positions

Tested on Ubuntu 24.04 LTS (Noble) with Tinyproxy v1.11.1

https://github.com/tinyproxy/tinyproxy/compare/1.10.0...1.11.1